### PR TITLE
[SA-68] fix undefined command: "install-peers"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {
-    "@magento/peregrine": "~11.0.0",
-    "@magento/pwa-buildpack": "~10.0.0",
-    "@magento/venia-ui": "~8.0.0"
+  "devDependencies": {
+    "install-peers-cli": "^2.2.0"
   }
 }


### PR DESCRIPTION
added dev dependency for `install-peers-cli` to fix undefined command: "install-peers"
also dependencies no need anymore because `install-peers` command will install it during development