### PR TITLE
fix css include on magento studio v12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     ]
   },
   "peerDependencies": {
-    "@magento/peregrine": "~11.0.0",
-    "@magento/pwa-buildpack": "~10.0.0",
-    "@magento/venia-ui": "~8.0.0",
+    "@magento/peregrine": "~12.1.0",
+    "@magento/pwa-buildpack": "~11.0.0",
+    "@magento/venia-ui": "~9.1.0",
     "react": "~17.0.1",
     "react-intl": "~5.7.0",
     "react-router-dom": "~5.1.0"
@@ -33,10 +33,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "dependencies": {
-    "@magento/peregrine": "~11.0.0",
-    "@magento/pwa-buildpack": "~10.0.0",
-    "@magento/venia-ui": "~8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {
-    "@magento/peregrine": "~11.0.0",
-    "@magento/pwa-buildpack": "~10.0.0",
-    "@magento/venia-ui": "~8.0.0"
+  "devDependencies": {
+    "install-peers-cli": "^2.2.0"
   }
 }

--- a/src/components/successPage/successPage.js
+++ b/src/components/successPage/successPage.js
@@ -17,7 +17,7 @@ import {StoreTitle} from "@magento/venia-ui/lib/components/Head";
 import {FormattedMessage, useIntl} from "react-intl";
 import ItemsReview from "@magento/venia-ui/lib/components/CheckoutPage/ItemsReview";
 import confirmationPageClasses
-    from "@magento/venia-ui/lib/components/CheckoutPage/OrderConfirmationPage/orderConfirmationPage.css";
+    from "@magento/venia-ui/lib/components/CheckoutPage/OrderConfirmationPage/orderConfirmationPage.module.css";
 import {useSuccessPage} from "../../talons/successPage/useSuccessPage";
 import LoadingIndicator from "@magento/venia-ui/lib/components/LoadingIndicator";
 import CreateAccount from "@magento/venia-ui/lib/components/CheckoutPage/OrderConfirmationPage/createAccount";

--- a/src/override/CheckoutPage/PaymentInformation/paymentMethods.js
+++ b/src/override/CheckoutPage/PaymentInformation/paymentMethods.js
@@ -16,7 +16,7 @@ import {mergeClasses} from '@magento/venia-ui/lib/classify';
 import {isMultisafepayPayment} from '../../../utils/Payment';
 import Radio from '@magento/venia-ui/lib/components/RadioGroup/radio';
 import paymentMethodOperations from './paymentMethods.gql';
-import defaultClasses from '@magento/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.css';
+import defaultClasses from '@magento/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.module.css';
 import payments from '@magento/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethodCollection';
 import Image from '@magento/venia-ui/lib/components/Image';
 


### PR DESCRIPTION
magento/venia-ui added *.module.css and tried to implement themes
that's why they renamed css which multisafepay module used during override checkout