### PR TITLE
fix Cannot destructure property 'image' of 'multisafepayPaymentAdditi…

### DIFF
--- a/src/override/CheckoutPage/PaymentInformation/paymentMethods.js
+++ b/src/override/CheckoutPage/PaymentInformation/paymentMethods.js
@@ -55,7 +55,7 @@ const PaymentMethods = props => {
                 return;
             }
 
-            const multisafepayPaymentAdditionalData = availablePaymentMethods[index].multisafepay_additional_data;
+            const multisafepayPaymentAdditionalData = availablePaymentMethods[index].multisafepay_additional_data || {};
 
             if (isMultisafepayPayment(code) && multisafepayPaymentAdditionalData.is_preselected) {
                 multisafepayPreselectedMethod = code;


### PR DESCRIPTION
fix Cannot destructure property 'image' fix-undefined-method-dataonalData' as it is undefined.

problem occured when module temporary disabled on backend but compiled in PWA bundle